### PR TITLE
Parallel starting and stopping of workers

### DIFF
--- a/doc/src/guide/changelog.asciidoc
+++ b/doc/src/guide/changelog.asciidoc
@@ -23,7 +23,10 @@ Mostly refactoring, cleanup, and some new features.
 
 === 0.3.0
 
-Mostly refactoring and cleanup.
+Mostly refactoring and cleanup, and some new features.
+
+* Workers are started and stopped in parallel, ie do not slow down
+  each other.
 
 * `prune/1`: Shrink the pool by evicting idle workers.
 

--- a/doc/src/guide/misc.asciidoc
+++ b/doc/src/guide/misc.asciidoc
@@ -1,16 +1,19 @@
 == Miscellaneous
 
-=== Worker startup and shutdown phases
+=== Prolonged worker startup phases
 
-You should keep the startup and shutdown phases of workers as short
-as possible, otherwise the performance of the pool in terms
-of checkout time will suffer when it needs to start a new worker to
-satisfy a checkout request.
+When a pool needs to start new workers to satisfy checkout
+requests, it does so in parallel. +
+This means that, when several checkout requests arrive at about
+the same time, for which new workers need to be started, the
+a worker does not have to wait for the ones before to complete
+their start phase before it can be started.
+
+Still, you may want to keep the startup phases of your workers
+as short as possible, since a user will still have to wait for
+that amount of time before it receives a newly started worker.
 
 To achieve short startup phases, you may consider returning
 the worker pid from the respective `start_link/1` function
 immediately, and do any initialization in a separate step,
 maybe even when the worker is being used for the first time.
-
-To achieve short shutdown phases, your worker may fire off a
-separate process to do the cleanup, and exit itself.

--- a/ebin/hnc.app
+++ b/ebin/hnc.app
@@ -1,7 +1,7 @@
 {application, 'hnc', [
 	{description, "hnc - Erlang Worker Pool"},
 	{vsn, "0.3.0"},
-	{modules, ['hnc','hnc_app','hnc_pool','hnc_pool_sup','hnc_sup','hnc_worker','hnc_worker_sup']},
+	{modules, ['hnc','hnc_app','hnc_pool','hnc_pool_sup','hnc_sup','hnc_worker','hnc_worker_sup','hnc_worker_sup_sup']},
 	{registered, [hnc_sup]},
 	{applications, [kernel,stdlib]},
 	{mod, {hnc_app, []}},

--- a/src/hnc_worker_sup.erl
+++ b/src/hnc_worker_sup.erl
@@ -17,42 +17,44 @@
 
 -behavior(supervisor).
 
--export([start_link/3]).
--export([start_worker/1, stop_worker/2]).
+-export([start_link/5]).
 -export([init/1]).
+-export([wait_worker/1]).
+-export([stop_worker/1]).
 
--spec start_link(module(), term(), hnc:shutdown()) -> {ok, pid()}.
-start_link(Mod, Args, Shutdown) ->
-	supervisor:start_link(?MODULE, {Mod, Args, Shutdown}).
+-spec start_link(module(), term(), hnc:shutdown(), [module()], pid()) -> {ok, pid()}.
+start_link(Mod, Args, Shutdown, Modules, ReportTo) ->
+	supervisor:start_link(?MODULE, {Mod, Args, Shutdown, Modules, ReportTo}).
 
--spec start_worker(pid()) -> {ok, hnc:worker()}.
-start_worker(Sup) ->
-	supervisor:start_child(Sup, []).
+-spec wait_worker(pid()) -> {ok, hnc:worker()} | {error, term()} | term().
+wait_worker(Sup) ->
+	receive
+		{worker_start, Sup, {ok, Worker}} when is_pid(Worker) -> {ok, Worker};
+		{worker_start, Sup, {ok, NotWorker}} -> {error, {not_a_worker, NotWorker}};
+		{worker_start, Sup, {error, {Reason, _}}} -> {error, Reason};
+		{worker_start, Sup, Other} -> Other
+	end.
 
--spec stop_worker(pid(), hnc:worker()) -> ok.
-stop_worker(Sup, Worker) ->
-	supervisor:terminate_child(Sup, Worker).
+-spec stop_worker(pid()) -> ok.
+stop_worker(Sup) ->
+	supervisor:terminate_child(Sup, hnc_worker).	
 
-init({Mod, Args, Shutdown}) ->
-	{module, Mod}=code:ensure_loaded(Mod),
-	Modules=case erlang:function_exported(Mod, get_modules, 0) of
-		true -> Mod:get_modules();
-		false -> [Mod]
-	end,
-	{
-		ok,
-		{
-			#{
-				strategy => simple_one_for_one
-			},
-			[
+init({Mod, Args, Shutdown, Modules, ReportTo}) ->
+	ok=logger:update_process_metadata(#{hnc => #{module => ?MODULE}}),
+	Self=self(),
+	_=spawn_link(
+		fun () ->
+			Res=supervisor:start_child(
+				Self,
 				#{
 					id => hnc_worker,
 					start => {Mod, start_link, [Args]},
-					restart => temporary,
+					restart => permanent,
 					shutdown => Shutdown,
 					modules => Modules
 				}
-			]
-		}
-	}.
+			),
+			ReportTo ! {worker_start, Self, Res}
+		end
+	),
+	{ok, {#{intensity=>0}, []}}.

--- a/src/hnc_worker_sup_sup.erl
+++ b/src/hnc_worker_sup_sup.erl
@@ -13,42 +13,45 @@
 %% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 %% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
--module(hnc_pool_sup).
+-module(hnc_worker_sup_sup).
 
 -behavior(supervisor).
 
--export([start_link/4]).
--export([start_worker_sup_sup/4]).
+-export([start_link/3]).
+-export([start_worker_sup/1, stop_worker_sup/2]).
 -export([init/1]).
 
--spec start_link(hnc:pool(), hnc:opts(), module(), term()) -> {ok, pid()}.
-start_link(Name, Opts, Mod, Args) ->
-	supervisor:start_link(?MODULE, {Name, Opts, Mod, Args}).
+-spec start_link(module(), term(), hnc:shutdown()) -> {ok, pid()}.
+start_link(Mod, Args, Shutdown) ->
+	supervisor:start_link(?MODULE, {Mod, Args, Shutdown}).
 
--spec start_worker_sup_sup(pid(), module(), term(), timeout() | brutal_kill) -> {ok, pid()}.
-start_worker_sup_sup(Sup, Mod, Args, Shutdown) ->
-	supervisor:start_child(
-		Sup,
-		#{
-			id => hnc_worker_sup_sup,
-			start => {hnc_worker_sup_sup, start_link, [Mod, Args, Shutdown]},
-			restart => permanent,
-			type => supervisor
-		}
-	).
+-spec start_worker_sup(pid()) -> {ok, pid()}.
+start_worker_sup(Sup) ->
+	supervisor:start_child(Sup, [self()]).
 
-init({Name, Opts, Mod, Args}) ->
+-spec stop_worker_sup(pid(), pid()) -> ok.
+stop_worker_sup(Sup, WorkerSup) ->
+	supervisor:terminate_child(Sup, WorkerSup).
+
+init({Mod, Args, Shutdown}) ->
+	{module, Mod}=code:ensure_loaded(Mod),
+	Modules=case erlang:function_exported(Mod, get_modules, 0) of
+		true -> Mod:get_modules();
+		false -> [Mod]
+	end,
+	ok=logger:update_process_metadata(#{hnc => #{module => ?MODULE}}),
 	{
 		ok,
 		{
 			#{
-				strategy => one_for_all
+				strategy => simple_one_for_one
 			},
 			[
 				#{
-					id => hnc_pool,
-					start => {hnc_pool, start_link, [Name, Opts, Mod, Args]},
-					restart => permanent
+					id => hnc_worker_sup,
+					start => {hnc_worker_sup, start_link, [Mod, Args, Shutdown, Modules]},
+					restart => temporary,
+					type => supervisor
 				}
 			]
 		}


### PR DESCRIPTION
This achieves one of the big goals we had for hnc from the beginning, but never found a solution for: the parallel starting and stopping of workers despite the fact that supervisors (workers_sup in our case) do this in linear/synchronous fashion.

In a nutshell, the workers_sup (now workers_sup_sup) does not start (or stop) the workers directly any more, but starts another supervisor (which finishes quickly), and that supervisor can then start the real worker without blocking the supervisor on top of it.